### PR TITLE
build(studio): force docker image to latest for dev platforms

### DIFF
--- a/dev-platforms/tasks/generate-helm-values.sh
+++ b/dev-platforms/tasks/generate-helm-values.sh
@@ -21,6 +21,9 @@ client_secret="$(jq -r .client_secret < "${github_app_dir}/metadata")"
 cat > "${helm_dir}/values.yml" <<EOF
 domain: ${name}.${DOMAIN}
 
+studio:
+  image: storyscript/studio:latest
+
 postgresql:
   create: false
   postgresqlHost: ${db_ip}


### PR DESCRIPTION
Now that the storyscript-chart uses :lts, we need to enforce
the usage of the dev image dor the dev platforms.