### PR TITLE
create-dev-platform: `try` all steps `on_failure`

### DIFF
--- a/dev-platforms/pipeline.yml
+++ b/dev-platforms/pipeline.yml
@@ -124,20 +124,23 @@ jobs:
             remove: github-apps-pool/
         on_failure:
           do:
-            - put: platform-terraform
-              params:
-                action: destroy
-                env_name_file: platform-terraform/name
-                terraform_source: studio-deployment/
-                vars: *terraform-vars
-              get_params:
-                action: destroy
-            - put: github-apps-pool
-              params:
-                release: github-apps-pool/
-            - put: building-pool
-              params:
-                remove: building-pool/
+            - try:
+                put: platform-terraform
+                params:
+                  action: destroy
+                  env_name_file: platform-terraform/name
+                  terraform_source: studio-deployment/
+                  vars: *terraform-vars
+                get_params:
+                  action: destroy
+            - try:
+                put: github-apps-pool
+                params:
+                  release: github-apps-pool/
+            - try:
+                put: building-pool
+                params:
+                  remove: building-pool/
 
   - name: delete-dev-platform
     plan:


### PR DESCRIPTION
Need to release the `github-apps-pool` lock even if destroying `platform-terraform` fails