### PR TITLE
create-dev-platform: use correct env_name_file to destroy platform-terraform on_failure

### DIFF
--- a/dev-platforms/pipeline.yml
+++ b/dev-platforms/pipeline.yml
@@ -127,7 +127,7 @@ jobs:
             - put: platform-terraform
               params:
                 action: destroy
-                env_name_file: platform-terraform/name
+                env_name_file: github-apps-pool/name
                 terraform_source: studio-deployment/
                 vars: *terraform-vars
               get_params:


### PR DESCRIPTION
See failed build [#420](https://concourse.storyscript-ci.com/teams/main/pipelines/dev-platforms/jobs/create-dev-platform/builds/420#L5e39865a:1)